### PR TITLE
Modification des éléments par le PO ou les Devs - Done

### DIFF
--- a/src/Controller/ElementController.php
+++ b/src/Controller/ElementController.php
@@ -5,6 +5,7 @@ namespace App\Controller;
 use App\Entity\Element;
 use App\Form\ElementPoType;
 use App\Form\ElementDevNewType;
+use App\Form\ElementDevEditType;
 use App\Repository\ElementRepository;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
@@ -90,6 +91,28 @@ class ElementController extends AbstractController
         }
 
         return $this->render('element/edit_po.html.twig', [
+            'element' => $element,
+            'form' => $form->createView(),
+        ]);
+    }
+
+    /**
+     * @Route("/dev/{id}/edit", name="element_dev_edit", methods={"GET","POST"})
+     */
+    public function editDev(Request $request, Element $element): Response
+    {
+        $form = $this->createForm(ElementDevEditType::class, $element);
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            $this->getDoctrine()->getManager()->flush();
+
+            return $this->redirectToRoute('element_index', [
+                'id' => $element->getId(),
+            ]);
+        }
+
+        return $this->render('element/edit_dev.html.twig', [
             'element' => $element,
             'form' => $form->createView(),
         ]);

--- a/src/Form/ElementDevEditType.php
+++ b/src/Form/ElementDevEditType.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Form;
+
+use App\Entity\Element;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\IntegerType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class ElementDevEditType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder
+            ->add('complexity',IntegerType::class, array('label'=>'Points de complexité'))
+            ->add('nbHours',IntegerType::class, array('label'=>'Nombre d\'heures estimé'))
+        ;
+    }
+
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults([
+            'data_class' => Element::class,
+        ]);
+    }
+}

--- a/src/Form/ElementPoType.php
+++ b/src/Form/ElementPoType.php
@@ -23,15 +23,13 @@ class ElementPoType extends AbstractType
                 'Correction'=>'correction',
                 'Users Stories'=>'userstory'
             )))
-            ->add('state',ChoiceType::class, array('label'=>'Type de l\'élément', 'choices'=>array(
+            ->add('state',ChoiceType::class, array('label'=>'Etat de l\'élément', 'choices'=>array(
                 'To Do'=>'todo',
                 'Doing'=>'doing',
                 'Done'=>'done',
                 'En attente'=>'attente'
             )))
             ->add('position',IntegerType::class, array('label'=>'Ordonnencement de l\'élément'))
-            ->add('complexity',IntegerType::class, array('label'=>'Points de complexité'))
-            ->add('nbHours',IntegerType::class, array('label'=>'Nombre d\'heures estimé'))
             ->add('acceptationCriteria', TextareaType::class, array('label'=>'Critères d\'acceptations'))
         ;
     }

--- a/templates/element/_form_dev_edit.html.twig
+++ b/templates/element/_form_dev_edit.html.twig
@@ -1,0 +1,48 @@
+{{ form_start(form) }}
+
+
+<div class="form-group">
+    <label>Titre de l'élément</label>
+    <input type="text" class="form-control" disabled value="{{ element.title }}">
+</div>
+<div class="form-group">
+    <label>Description de l'élément</label>
+    <textarea class="form-control" disabled>{{ element.description }}</textarea>
+</div>
+<div class="form-group">
+    <label>Type de l'élément</label>
+    <select class="form-control" disabled>
+        <option>{{ element.type }}</option>
+    </select>
+</div>
+<div class="form-group">
+    <label>Critères d'acceptations</label>
+    <textarea class="form-control" disabled>{{ element.acceptationCriteria }}</textarea>
+</div>
+<div class="form-group">
+    <label>Ordonnencement de l'élément</label>
+    <input type="integer" class="form-control" disabled value="{{ element.position }}">
+</div>
+<div class="form-group">
+    <label>Etat de l'élément</label>
+    <select class="form-control" disabled>
+        <option>{{ element.state }}</option>
+    </select>
+</div>
+<div class="form-group">
+    {{ form_label(form.complexity, 'Points de complexité estimés') }}
+    {{ form_widget(form.complexity, {'attr': {'class': 'form-control'}}) }}
+</div>
+<div class="form-group">
+    {{ form_label(form.nbHours, 'Nombre d\'heures estimé') }}
+    {{ form_widget(form.nbHours, {'attr': {'class': 'form-control'}}) }}
+</div>
+
+{{ form_row(form._token) }}
+
+    <button class="btn btn-perso">{{ button_label|default('Save') }}</button>
+
+{{ form_end(form, {'render_rest': false}) }}
+
+
+

--- a/templates/element/edit_dev.html.twig
+++ b/templates/element/edit_dev.html.twig
@@ -5,7 +5,7 @@
 {% block body %}
     <h1>Modifier l'élément</h1>
 
-    {{ include('element/_form_po.html.twig', {'button_label': 'Update'}) }}
+    {{ include('element/_form_dev_edit.html.twig', {'button_label': 'Update'}) }}
 
     <a href="{{ path('element_index') }}">back to list</a>
 


### PR DESCRIPTION
Tous les utilisateurs peuvent désormais modifier les éléments.

Dans le cas du PO : 
 - "base_url/element/po/{id_de_element_a_modifier}/edit"
Dans le cas de l'équipe de développement : 
 - "base_url/element/dev/{id_de_element_a_modifier}/edit"

la redirection automatique n'est pas finalisé pour les mêmes raisons que la créations des éléments.

Issue liée : #9 